### PR TITLE
add SAMPLE-AES-CTR support

### DIFF
--- a/src/main/java/io/lindstrom/m3u8/model/KeyMethod.java
+++ b/src/main/java/io/lindstrom/m3u8/model/KeyMethod.java
@@ -1,7 +1,7 @@
 package io.lindstrom.m3u8.model;
 
 public enum KeyMethod {
-    NONE, AES_128, SAMPLE_AES;
+    NONE, AES_128, SAMPLE_AES, SAMPLE_AES_CTR;
 
     @Override
     public String toString() {
@@ -10,6 +10,8 @@ public enum KeyMethod {
                 return AES_128_STRING;
             case SAMPLE_AES:
                 return SAMPLE_AES_STRING;
+            case SAMPLE_AES_CTR:
+                return SAMPLE_AES_CTR_STRING;
             default:
                 return super.toString();
         }
@@ -21,6 +23,8 @@ public enum KeyMethod {
                 return AES_128;
             case SAMPLE_AES_STRING:
                 return SAMPLE_AES;
+            case SAMPLE_AES_CTR_STRING:
+                return SAMPLE_AES_CTR;
             default:
                 return KeyMethod.valueOf(name);
         }
@@ -28,4 +32,5 @@ public enum KeyMethod {
 
     private static final String AES_128_STRING = "AES-128";
     private static final String SAMPLE_AES_STRING = "SAMPLE-AES";
+    private static final String SAMPLE_AES_CTR_STRING = "SAMPLE-AES-CTR";
 }


### PR DESCRIPTION
Added support for this KeyMethod to prevent throwing on parsing a manifest that contains it. Example attached

[ExampleSampleAesCtrManifest.txt](https://github.com/carlanton/m3u8-parser/files/9769362/ExampleSampleAesCtrManifest.txt)
