### PR TITLE
Reorder Session-Data and Session-Key tags in MasterPlaylistTag

### DIFF
--- a/src/main/java/io/lindstrom/m3u8/parser/MasterPlaylistTag.java
+++ b/src/main/java/io/lindstrom/m3u8/parser/MasterPlaylistTag.java
@@ -3,7 +3,6 @@ package io.lindstrom.m3u8.parser;
 import io.lindstrom.m3u8.model.MasterPlaylist;
 
 import java.util.Map;
-import java.util.Optional;
 
 enum MasterPlaylistTag implements Tag<MasterPlaylist, MasterPlaylist.Builder> {
     EXT_X_VERSION {
@@ -56,6 +55,30 @@ enum MasterPlaylistTag implements Tag<MasterPlaylist, MasterPlaylist.Builder> {
         }
     },
 
+    EXT_X_SESSION_DATA {
+        @Override
+        public void read(MasterPlaylist.Builder builder, String attributes, ParsingMode parsingMode) throws PlaylistParserException {
+            builder.addSessionData(SessionDataAttribute.parse(attributes, parsingMode));
+        }
+
+        @Override
+        public void write(MasterPlaylist playlist, TextBuilder textBuilder) {
+            textBuilder.addTag(tag(), playlist.sessionData(), SessionDataAttribute.attributeMap);
+        }
+    },
+
+    EXT_X_SESSION_KEY {
+        @Override
+        public void read(MasterPlaylist.Builder builder, String attributes, ParsingMode parsingMode) throws PlaylistParserException {
+            builder.addSessionKeys(SegmentKeyAttribute.parse(attributes, parsingMode));
+        }
+
+        @Override
+        public void write(MasterPlaylist playlist, TextBuilder textBuilder) {
+            textBuilder.addTag(tag(), playlist.sessionKeys(), SegmentKeyAttribute.attributeMap);
+        }
+    },
+
     EXT_X_MEDIA {
         @Override
         public void read(MasterPlaylist.Builder builder, String attributes, ParsingMode parsingMode) throws PlaylistParserException {
@@ -92,30 +115,6 @@ enum MasterPlaylistTag implements Tag<MasterPlaylist, MasterPlaylist.Builder> {
         @Override
         public void write(MasterPlaylist playlist, TextBuilder textBuilder) {
             textBuilder.addTag(tag(), playlist.iFrameVariants(), IFrameVariantAttribute.attributeMap);
-        }
-    },
-
-    EXT_X_SESSION_DATA {
-        @Override
-        public void read(MasterPlaylist.Builder builder, String attributes, ParsingMode parsingMode) throws PlaylistParserException {
-            builder.addSessionData(SessionDataAttribute.parse(attributes, parsingMode));
-        }
-
-        @Override
-        public void write(MasterPlaylist playlist, TextBuilder textBuilder) {
-            textBuilder.addTag(tag(), playlist.sessionData(), SessionDataAttribute.attributeMap);
-        }
-    },
-
-    EXT_X_SESSION_KEY {
-        @Override
-        public void read(MasterPlaylist.Builder builder, String attributes, ParsingMode parsingMode) throws PlaylistParserException {
-            builder.addSessionKeys(SegmentKeyAttribute.parse(attributes, parsingMode));
-        }
-
-        @Override
-        public void write(MasterPlaylist playlist, TextBuilder textBuilder) {
-            textBuilder.addTag(tag(), playlist.sessionKeys(), SegmentKeyAttribute.attributeMap);
         }
     },
 


### PR DESCRIPTION
We are experimenting with using EXT-X-SESSION-DATA tags to supply additional data in our manifests but have noticed that when the manifest is written out, the Session Data is written out at the very bottom of the manifest file. Best practice seems to be that this data should be written out before any media segment tags. 

This change is a mere reordering of the elements in the MasterPlaylistTag class so that the Session tags are placed in a more appropriate place in the resulting manifest text. 